### PR TITLE
Activate autofs service after OS install.

### DIFF
--- a/os.yml
+++ b/os.yml
@@ -11,4 +11,7 @@
       - cxoracle
       - orahost-logrotate
 
-
+   post_tasks:
+      - name: Restart autofs
+        service: name=autofs enabled=yes state=restarted
+        tags: autofs


### PR DESCRIPTION
To enable Oracle software install from nfs via Autofs. The existing roles install autofs but don't activate it.